### PR TITLE
Fix wrong URL and add meetings section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This initiative adopts the general Node.js [Code of Conduct], as well as its own
 
 ## Meetings
 
-Meetings are held every two weeks. Can access pieces of information in the meetings at [Meeting notes storage]. Organizational plans or related future meetings are available at [here](https://github.com/nodejs/website-redesign/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+Meeting+in%3Atitle)
+Meeting notes can be accessed [here](./meetings). Future meetings can be listed using [this link](https://github.com/nodejs/website-redesign/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+Meeting+in%3Atitle).
 
 ## Team
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ cross-cutting concerns with other groups such as the Internationalization WG.
 This initiative adopts the general Node.js [Code of Conduct], as well as its own
 [contributing guidelines].
 
+## Meetings
+
+Meetings are held every two weeks. Can access pieces of information in the meetings at [Meeting notes storage]. Organizational plans or related future meetings are available at [here](https://github.com/nodejs/website-redesign/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aopen+Meeting+in%3Atitle)
+
 ## Team
 
-- [@oe](https://githuhttps://github.com/nodejs/website-redesignb.com/oe) - **Olivia Hugger**, Community Committee Champion
+- [@oe](https://github.com/oe) - **Olivia Hugger**, Community Committee Champion
 - [@fhemberger](https://github.com/fhemberger) - **Frederic Hemberger**
 - [@bnb](https://github.com/bnb) - **Tierney Cyren**
 - [@CodeTheory](https://github.com/CodeTheory) - **Timothy**
@@ -29,3 +33,4 @@ This initiative adopts the general Node.js [Code of Conduct], as well as its own
 [Community Committee]: https://github.com/nodejs/community-committee
 [Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
 [contributing guidelines]: ./CONTRIBUTING.md
+[Meeting notes storage]: ./meetings


### PR DESCRIPTION
Fix the wrong URL at `README.md` and I think should add `meetings` section to connect to the meeting information more quickly.
Have to merged #7 first.