### PR TITLE
Update Members and Co-Champions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Meeting notes can be accessed [here](./meetings). Future meetings can be listed 
 ## Team
 **[@nodejs/website-redesign](https://github.com/nodejs/website-redesign)**
 
-Any person who wants to contribute to the initiative is welcome! Please read [CONTRIBUTING](https://github.com/nodejs/website-redesign/blob/update-members-and-champions/CONTRIBUTING.md) and join the effort 🙌
+Any person who wants to contribute to the initiative is welcome! Please read [CONTRIBUTING.md](https://github.com/nodejs/website-redesign/blob/update-members-and-champions/CONTRIBUTING.md) and join the effort 🙌
 
 Any member of the website-redesign initiative attached to the current phase of the project will be added to a future phase as the project moves forward.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Meeting notes can be accessed [here](./meetings). Future meetings can be listed 
 ## Team
 **[@nodejs/website-redesign](https://github.com/nodejs/website-redesign)**
 
-Any person who wants to contribute to the initiative is welcome! Please read [CONTRIBUTING.md](https://github.com/nodejs/website-redesign/blob/update-members-and-champions/CONTRIBUTING.md) and join the effort 🙌
+Any person who wants to contribute to the initiative is welcome! Please read [CONTRIBUTING](https://github.com/nodejs/website-redesign/blob/update-members-and-champions/CONTRIBUTING.md) and join the effort 🙌
 
 Any member of the website-redesign initiative attached to the current phase of the project will be added to a future phase as the project moves forward.
 
@@ -57,7 +57,7 @@ Any member of the website-redesign iniative who prefers to begin contributing at
 - [@Qard](https://github.com/Qard) - **Stephen Belanger**
 - [@watilde](https://github.com/watilde) - **Daijiro Wachi**
 - [@tolmasky](https://github.com/tolmasky) - **Francisco Ryan Tolmasky I**
-- [@milapbhojak] (https://github.com/milapbhojak) - **Milap Bhojak**
+- [@milapbhojak](https://github.com/milapbhojak) - **Milap Bhojak**
 
 ### Design
 

--- a/README.md
+++ b/README.md
@@ -18,34 +18,60 @@ Meeting notes can be accessed [here](./meetings). Future meetings can be listed 
 ## Team
 **[@nodejs/website-redesign](https://github.com/nodejs/website-redesign)**
 
+Any person who wants to contribute to the initiative is welcome! Please read [CONTRIBUTING.md](https://github.com/nodejs/website-redesign/blob/update-members-and-champions/CONTRIBUTING.md) and join the effort 🙌
+
+Any member of the website-redesign initiative attached to the current phase of the project will be added to a future phase as the project moves forward.
+
+Any member of the website-redesign iniative who prefers to begin contributing at a specific future phase is welcome to make a PR adding their handle to that phase.
+
+- [@amiller-gh](https://github.com/amiller-gh) - **Adam Miller**, CommComm Co-champion
+- [@chowdhurian](https://github.com/chowdhurian) - **Manil Chowdhury**, CommComm Co-champion
+
 ### Information Gathering
+
+- [@amiller-gh](https://github.com/amiller-gh) - **Adam Miller**
+- [@codeekage](https://github.com/codeekage) - **Agiri Abraham JNR**
+- [@darcyclarke](https://github.com/darcyclarke) - **Darcy Clarke**
+- [@maddhruv](https://github.com/maddhruv) - **Dhruv Jain**
+- [@fhemberger](https://github.com/fhemberger) - **Frederic Hemberger**
+- [@JonahMoses](https://github.com/JonahMoses) - **Jonah Moses**
+- [@chowdhurian](https://github.com/chowdhurian) - **Manil Chowdhury**
+- [@oe](https://github.com/oe) - **Olivia Hugger**
+- [@bnb](https://github.com/bnb) - **Tierney Cyren**
+- [@timothyis](https://github.com/timothyis) - **Timothy**
+
+### Planning _<-- current phase_
 
 - [@oe](https://github.com/oe) - **Olivia Hugger**
 - [@fhemberger](https://github.com/fhemberger) - **Frederic Hemberger**
 - [@bnb](https://github.com/bnb) - **Tierney Cyren**
-- [@CodeTheory](https://github.com/CodeTheory) - **Timothy**
-- [@jestho](https://github.com/jestho) - **Jesper Thøgersen**
+- [@timothyis](https://github.com/timothyis) - **Timothy**
 - [@JonahMoses](https://github.com/JonahMoses) - **Jonah Moses**
-- [@amiller-gh](https://github.com/amiller-gh) - **Adam Miller**, CommComm Co-champion
-- [@skllcrn](https://github.com/skllcrn) - **Christopher Skillicorn**
-- [@pierreneter](https://github.com/pierreneter) - **Pierre Neter**
+- [@amiller-gh](https://github.com/amiller-gh) - **Adam Miller**
 - [@emilypmendez](https://github.com/emilypmendez) - **Emily Mendez**
 - [@darcyclarke](https://github.com/darcyclarke) - **Darcy Clarke**
 - [@maddhruv](https://github.com/maddhruv) - **Dhruv Jain**
-- [@chowdhurian](https://github.com/chowdhurian) - **Manil Chowdhury**, CommComm Co-champion
+- [@chowdhurian](https://github.com/chowdhurian) - **Manil Chowdhury**
 - [@codeekage](https://github.com/codeekage) - **Agiri Abraham JNR**
-
-### Planning _<-- current phase_
+- [@add1sun](https://github.com/add1sun) - **Addison Berry**
+- [@Qard](https://github.com/Qard) - **Stephen Belanger**
+- [@watilde](https://github.com/watilde) - **Daijiro Wachi**
+- [@tolmasky](https://github.com/tolmasky) - **Francisco Ryan Tolmasky I**
 
 ### Design
 
 ### Development
+
+- [@jestho](https://github.com/jestho) - **Jesper Thøgersen**
 
 ### Testing
 
 ### Launch
 
 ### Maintenance
+
+
+## Links
 
 [Community Committee]: https://github.com/nodejs/community-committee
 [Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ Any member of the website-redesign iniative who prefers to begin contributing at
 
 ## Links
 
-[Community Committee]: https://github.com/nodejs/community-committee
-[Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md
-[contributing guidelines]: ./CONTRIBUTING.md
-[Meeting notes storage]: ./meetings
+[Community Committee](https://github.com/nodejs/community-committee)
+
+[Code of Conduct](https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md)
+
+[contributing guidelines](./CONTRIBUTING.md)
+
+[Meeting notes storage](./meetings)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Meeting notes can be accessed [here](./meetings). Future meetings can be listed 
 ## Team
 **[@nodejs/website-redesign](https://github.com/nodejs/website-redesign)**
 
+### Information Gathering
+
 - [@oe](https://github.com/oe) - **Olivia Hugger**
 - [@fhemberger](https://github.com/fhemberger) - **Frederic Hemberger**
 - [@bnb](https://github.com/bnb) - **Tierney Cyren**
@@ -32,6 +34,18 @@ Meeting notes can be accessed [here](./meetings). Future meetings can be listed 
 - [@maddhruv](https://github.com/maddhruv) - **Dhruv Jain**
 - [@chowdhurian](https://github.com/chowdhurian) - **Manil Chowdhury**, CommComm Co-champion
 - [@codeekage](https://github.com/codeekage) - **Agiri Abraham JNR**
+
+### Planning _<-- current phase_
+
+### Design
+
+### Development
+
+### Testing
+
+### Launch
+
+### Maintenance
 
 [Community Committee]: https://github.com/nodejs/community-committee
 [Code of Conduct]: https://github.com/nodejs/admin/blob/master/CODE_OF_CONDUCT.md

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Any member of the website-redesign iniative who prefers to begin contributing at
 - [@Qard](https://github.com/Qard) - **Stephen Belanger**
 - [@watilde](https://github.com/watilde) - **Daijiro Wachi**
 - [@tolmasky](https://github.com/tolmasky) - **Francisco Ryan Tolmasky I**
+- [@milapbhojak] (https://github.com/milapbhojak) - **Milap Bhojak**
 
 ### Design
 

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ Meeting notes can be accessed [here](./meetings). Future meetings can be listed 
 ## Team
 **[@nodejs/website-redesign](https://github.com/nodejs/website-redesign)**
 
-- [@oe](https://github.com/oe) - **Olivia Hugger**, Community Committee Champion
+- [@oe](https://github.com/oe) - **Olivia Hugger**
 - [@fhemberger](https://github.com/fhemberger) - **Frederic Hemberger**
 - [@bnb](https://github.com/bnb) - **Tierney Cyren**
 - [@CodeTheory](https://github.com/CodeTheory) - **Timothy**
 - [@jestho](https://github.com/jestho) - **Jesper Thøgersen**
 - [@JonahMoses](https://github.com/JonahMoses) - **Jonah Moses**
-- [@amiller-gh](https://github.com/amiller-gh) - **Adam Miller**
+- [@amiller-gh](https://github.com/amiller-gh) - **Adam Miller**, CommComm Co-champion
 - [@skllcrn](https://github.com/skllcrn) - **Christopher Skillicorn**
 - [@pierreneter](https://github.com/pierreneter) - **Pierre Neter**
 - [@emilypmendez](https://github.com/emilypmendez) - **Emily Mendez**
 - [@darcyclarke](https://github.com/darcyclarke) - **Darcy Clarke**
 - [@maddhruv](https://github.com/maddhruv) - **Dhruv Jain**
-- [@chowdhurian](https://github.com/chowdhurian) - **Manil Chowdhury**
+- [@chowdhurian](https://github.com/chowdhurian) - **Manil Chowdhury**, CommComm Co-champion
 - [@codeekage](https://github.com/codeekage) - **Agiri Abraham JNR**
 
 [Community Committee]: https://github.com/nodejs/community-committee


### PR DESCRIPTION
* Update champions per private session discussion in last Website Redesign meeting (#30) and Olivia's move to CommComm Emeriti ([#290](https://github.com/nodejs/community-committee/pull/290)).
* Add project phases.
* Attach members to the phases of the project in which they expressed an interest.
* Add people found within issues related to a future phase that were shelved for the time being.
* Remove dead handle.
* Remove inactive handles. If this was in error, please let me know or PR yourself back in! 🙏🏽