### PR TITLE
Moving to a folder structure for each article in /documentation

### DIFF
--- a/documentation/0000-template/article.md
+++ b/documentation/0000-template/article.md
@@ -12,6 +12,8 @@
 
 > Body content, including sub-headings (H3 or lower, using the appropriate H(n) level for the content's place in the document), prose, code samples, screenshots, etc.
 
+> Note: any included screenshots for your article should be saved in the same directory your article.md lives in!
+
 ## Conclusion
 
 > 1-2 paragraphs wrapping up the article

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -12,11 +12,11 @@ If you submit a pull request to implement a significant change to the documentat
 
 ## To begin drafting a documentation page:
 
- 1. Fork the [nodejs/website-redesign repo](https://github.com/nodejs/website-redesign).
- 2. Copy `getting-started-docs/0000-template.md` to `getting-started-docs/0000-my-article-name.md` (where 'my-article-name' is descriptive. Don't assign the page a number yet).
- 3. Fill in the RFC template. Put care into the details! Please review the proposed [Node.js Voice and Tone Guidelines](https://github.com/nodejs/website-redesign/blob/master/style-guide/0001-voice-and-tone.md) before you begin writing.
- 4. Submit a pull request. As a pull request the draft will receive feedback from the larger community, and the author should be prepared to revise it in response.
- 5. Build consensus and integrate feedback.
+ 1. Fork the [nodejs/website-redesign repo](https://github.com/nodejs/website-redesign) so that you have your own copy of the repository that you have push access to.
+ 2. Create a new folder for your documentation to live in by copying the given template folder found at `documentation/0000-template` to a new folder `documentation/0000-my-article-name` (replacing 'my-article-name' with a descriptive name of what your article is about. Leave the 0000 as it is, since we don't need to assign your article a page number yet).
+ 3. You should now have a new folder that contains an article.md file that will serve as the template that you will use for your documentation. Edit this article.md file and begin writing out your article. Put care into the details! Please review the proposed [Node.js Voice and Tone Guidelines](https://github.com/nodejs/website-redesign/blob/master/style-guide/0001-voice-and-tone.md) before you begin writing.
+ 4. When you are ready to get some feedback on your article, submit a pull request back to the main nodejs/website-redesign repository. As a pull request, the draft will receive feedback from the larger community, and the author should be prepared to revise it in response.
+ 5. Build consensus on your article by integrating feedback from the community.
  6. Eventually, the Website Redesign Working Group will decide in one of their bi-weekly meetings whether the RFC is a candidate for inclusion on the Node.js website.
 
 RFCs that are candidates for inclusion on the Node.js website will enter a "final comment period" lasting 7 days. The beginning of this period will be signaled with a comment and tag on the RFC's pull request. The RFC can be modified based upon feedback from the community. Significant modifications may trigger a new final comment period. At the close of this review period, the RFC may be:


### PR DESCRIPTION
Moving to a folder structure for each article in /documentation so related assets can be included.

Motivation:
We had a question about where to store screenshots for documentation that students were writing during Nodeschool YVR. @chowdhurian and I spoke briefly about this, and this solution is what we came up with.

Would love to see some feedback/suggestions! :D