### PR TITLE
Add links to resources containing background info

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ own [Contributing Guidelines][].
 [Meeting notes][] from past meetings are maintained for later reference.
 [Query issues for "Meeting"][] to find future meetings.
 
+## Summary / Current Status
+
+Our current focus is on UI design and content creation. You can get some background information by reading these two articles: [Redesigning Nodejs.org Part 1](https://medium.com/the-node-js-collection/redesigning-nodejs-part-1-fac08a0e015a) and [Redesigning Nodejs.org Part 2](https://medium.com/@ammiller/redesigning-nodejs-org-584212bb25e1). And browser the current working wirefames here https://projects.invisionapp.com/share/SJG12D028NX#/screens/281335816.
+
 ## Team
 
 **[@nodejs/website-redesign](https://github.com/nodejs/website-redesign)**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ own [Contributing Guidelines][].
 
 ## Summary / Current Status
 
-Our current focus is on UI design and content creation. You can get some background information by reading these two articles: [Redesigning Nodejs.org Part 1](https://medium.com/the-node-js-collection/redesigning-nodejs-part-1-fac08a0e015a) and [Redesigning Nodejs.org Part 2](https://medium.com/@ammiller/redesigning-nodejs-org-584212bb25e1). And browser the current working wirefames here https://projects.invisionapp.com/share/SJG12D028NX#/screens/281335816.
+Our current focus is on UI design and content creation. You can get some background information by reading these two articles: [Redesigning Nodejs.org Part 1](https://medium.com/the-node-js-collection/redesigning-nodejs-part-1-fac08a0e015a) and [Redesigning Nodejs.org Part 2](https://medium.com/@ammiller/redesigning-nodejs-org-584212bb25e1). And browse the current working wirefames [here](https://projects.invisionapp.com/share/SJG12D028NX#/screens/281335816).
 
 ## Team
 


### PR DESCRIPTION
At  the recent collaborators summit breakout about website re-design there were some useful links shared that contain a bunch of background information about the project. For someone who is just trying to figure out how I can help, and what the current state of things is, these were useful. Unfortunately I wouldn't have known about them if I hadn't been in the room when they were mentioned.

I think it might also be worthwhile to add links to one or two issues or areas of discussion that the group is currently focused on. This would help direct attention of anyone new to the project, or just curious about where things are at. (Heh, including me who is still trying to figure that out 😄). I don't know what those are though, so would be great if someone more familiar with the project could either add them, or let me know so I can add them.