### PR TITLE
Fixed Syntax Errors

### DIFF
--- a/documentation/0045-node-folders/index.md
+++ b/documentation/0045-node-folders/index.md
@@ -48,7 +48,7 @@ You can get the full path:
 ```js
 fs.readdirSync(folderPath).map(fileName => {
   return path.join(folderPath, fileName)
-}
+})
 ```
 
 You can also filter the results to only return the files, and exclude the folders:
@@ -59,8 +59,9 @@ const isFile = fileName => {
 }
 
 fs.readdirSync(folderPath).map(fileName => {
-  return path.join(folderPath, fileName)).filter(isFile)
-}
+  return path.join(folderPath, fileName)
+})
+.filter(isFile)
 ```
 
 ## Rename a folder

--- a/documentation/0051-node-buffers/index.md
+++ b/documentation/0051-node-buffers/index.md
@@ -114,7 +114,7 @@ By default you copy the whole buffer. 3 more parameters let you define the start
 
 ```js
 const buf = new Buffer('Hey!')
-let bufcopy = new Buffer(2) //allocate 4 bytes
+let bufcopy = new Buffer(2) //allocate 2 bytes
 buf.copy(bufcopy, 0, 2, 2)
 bufcopy.toString() //'He'
 ```


### PR DESCRIPTION
Fixed syntax errors in documents caused by the map function not have a closing bracket. 
Also fixed an incorrect comment.