### PR TITLE
Archival: Add Vancouver 2018 Collab Summit minutes

### DIFF
--- a/meetings/2018-10-13.md
+++ b/meetings/2018-10-13.md
@@ -1,0 +1,52 @@
+# Node.js Foundation Website Redesign Strategic Initiative Collab Summit Session 2018-10-13
+
+## Links
+
+* **Minutes Google Doc**: https://docs.google.com/document/d/16eRahz4dmoEBCyISoRr721Rg9gjCEXVRKVsz0RvxcUw/edit
+
+# Collab Summit
+
+## Present
+
+Francisco @tolmasky
+Joey @beefymcpound / @joeyellis
+Stephen @qard
+Manil @chowdhurian
+Adam @amiller-gh
+Jeremiah @fishrock123
+Tierney @bnb
+Joe @eojthebrave
+Matheus @mmarchini
+
+## Goals
+
+* Each person who wants to participate leaves with an action item, of large or small scope. May or may not include being onboarded.
+
+## Notes
+
+### Requirements gathering
+
+We would like to do it so that the next time a redesign happens, which it will, you don’t have to throw everything out. Should be like a UI consuming docs in markdown.
+
+Does content need to live with the repos that it describes?
+
+There is also content that is an artifact of something else in the ecosystem. e.g.) a list of historical builds, change records, code coverage stats. These will need to be ingested from wherever they live currently.
+
+Should the new website facilitate content from projects like llnode and N-API? Right now the content for these projects lives in their individual GitHub repos. Can/should it be surfaced on the main site? There should be policies/guidelines in place that outline what projects can surface their content onto the main site. Allow groups to opt-in to doing this rather than making it a requirement.
+
+### Hosting sub-projects in the site
+
+* N-API
+* llnode
+* node-gyp
+* canary-in-the-goldmine
+* nan
+* (docker images we publish)
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Node.js Foundation Calendar**: https://nodejs.org/calendar
+
+Click `+GoogleCalendar` at the bottom right to add to your own Google calendar


### PR DESCRIPTION
While doing a routine sweep, I found notes from the Collab Summit buried. They're not detailed, as we focused on discussions during the Summit. What *is* present I'm PRing for posterity.